### PR TITLE
Remove Tag and Collection from sonata news configuration file

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -34,14 +34,6 @@ Advanced Configuration
                 class:       Sonata\NewsBundle\Admin\CommentAdmin
                 controller:  SonataNewsBundle:CommentAdmin
                 translation: SonataNewsBundle
-            collection:
-                class:       Sonata\NewsBundle\Admin\CollectionAdmin
-                controller:  SonataAdminBundle:CRUD
-                translation: SonataNewsBundle
-            tag:
-                class:       Sonata\NewsBundle\Admin\TagAdmin
-                controller:  SonataAdminBundle:CRUD
-                translation: SonataNewsBundle
 
 .. code-block:: yaml
 


### PR DESCRIPTION
If you put them you have an exception: Unrecognized option "tag" under "sonata_news.admin". Available options are "comment", "post".

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
